### PR TITLE
fix missing space

### DIFF
--- a/src/pages/en/about.astro
+++ b/src/pages/en/about.astro
@@ -51,7 +51,7 @@ import Hero from "../../components/Hero.astro";
 				<h2 class="section-title">Skills</h2>
 				<div class="content">
 					<ul>
-						<li>Programming: C++, JS/TS,GDScript, C# (Unity)</li>
+						<li>Programming: C++, JS/TS, GDScript, C# (Unity)</li>
 						<li>Tools: Godot, WWise, Blender, Unity</li>
 					</ul>
 				</div>


### PR DESCRIPTION
fixes missing blank character in `/en/about/`

<img width="500" height="500" alt="Minor-Spelling-Mistake-HD-meme-2-487161988" src="https://github.com/user-attachments/assets/916c9470-363f-4436-94c2-9b677f7576d0" />

